### PR TITLE
Fix bug where `tags` directory causes error

### DIFF
--- a/ctagz.js
+++ b/ctagz.js
@@ -452,8 +452,14 @@ function findCTagsFile(searchPath, tagFilePattern = '{.,}tags') {
                     return acc
                 }
                 const matchPath = path.join(tagPath, match)
-                return fs.openAsync(matchPath, 'r').then(fd => new CTags(matchPath, fd))
-                .catch(() => {}) // EAFP
+                return fs.statAsync(matchPath).then(stats => {
+                    if (!stats.isFile()) {
+                        return Promise.resolve(null)
+                    }
+
+                    return fs.openAsync(matchPath, 'r').then(fd => new CTags(matchPath, fd))
+                    .catch(() => {}) // EAFP
+                })
             }, null)
 
             return ret.then(result => {


### PR DESCRIPTION
Fix a bug where the presence of a `tags` directory causes the error:

    Error: EISDIR: illegal operation on a directory, read

---

If merged, I'd also appreciate it if you'd cut a new version of [ctagsx](https://github.com/jtanx/ctagsx), @jtanx! This is where I happened upon this bug. 😄  Thanks.